### PR TITLE
JEA requires SessionType='RestrictedRemoteServer'

### DIFF
--- a/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
+++ b/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
@@ -58,6 +58,7 @@ class JeaEndpoint
         $configurationFileArguments = @{
             Path = $psscPath
             RoleDefinitions = $roleDefinitionsHash
+            SessionType = 'RestrictedRemoteServer'
         }
 
         if($this.RunAsVirtualAccountGroups -and $this.GroupManagedServiceAccount)


### PR DESCRIPTION
JEA will not push to remote systems properly without this change.

The key-value pair:

SessionType = 'RestrictedRemoteServer' 

must be added to the hashtable that is splatted into New-PSSessionConfigurationFile. Otherwise JEA endpoints deployed with this DSC Resource will simply not work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/jea/6)
<!-- Reviewable:end -->
