### PR TITLE
.psrc file must be copied before endpoint created

### DIFF
--- a/DSC Resource/DemoConfig.ps1
+++ b/DSC Resource/DemoConfig.ps1
@@ -17,5 +17,6 @@ Configuration JeaTest
         RoleDefinitions = "@{ 'CONTOSO\DnsAdmins' = @{ RoleCapabilities = 'DnsAdmin' } }"
         TranscriptDirectory = 'C:\ProgramData\JeaEndpoint\Transcripts'
         ScriptsToProcess = 'C:\ProgramData\JeaEndpoint\startup.ps1'
+        DependsOn = '[File]DnsAdminRoleCapability'
     }
 }


### PR DESCRIPTION
For this example to work as a baseline for others to build on, it really needs DependsOn added to the JeaEndpoint configuration so that it will not run until the file that it is dependent on has been copied first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/jea/7)
<!-- Reviewable:end -->
