### PR TITLE
Fix for BUG #11

### DIFF
--- a/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
+++ b/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
@@ -216,13 +216,17 @@ class JeaEndpoint
                 Write-Verbose "UserDriveMaximumSize not equal: $($currentInstance.UserDriveMaximumSize)"
                 return $false
             }
-
-            $requiredGroupsHash = $this.ConvertStringToHashtable($this.RequiredGroups)
-            if(-not $this.ComplexObjectsEqual($this.ConvertStringToHashtable($currentInstance.RequiredGroups), $requiredGroupsHash))
-            {
-                Write-Verbose "RequiredGroups not equal: $(ConvertTo-Json $currentInstance.RequiredGroups -Depth 100)"
-                return $false
+            # Check for null required groups
+            if($currentInstance.RequiredGroups -ne $null)
+            {    
+                $requiredGroupsHash = $this.ConvertStringToHashtable($this.RequiredGroups)
+                if(-not $this.ComplexObjectsEqual($this.ConvertStringToHashtable($currentInstance.RequiredGroups), $requiredGroupsHash))
+                {
+                    Write-Verbose "RequiredGroups not equal: $(ConvertTo-Json $currentInstance.RequiredGroups -Depth 100)"
+                    return $false
+                }
             }
+            
 
             return $true
         }


### PR DESCRIPTION
Added logic to test if required groups is null. The line 

$data = $ast.Find( { $args[0] -is [System.Management.Automation.Language.HashtableAst] }, $false )

returns no object if RequiredGroups contains no values.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/jea/15)
<!-- Reviewable:end -->
