### PR TITLE
Fix proposal for issue #28

### DIFF
--- a/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
+++ b/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
@@ -74,7 +74,7 @@ class JeaEndpoint
         }
         elseif($this.GroupManagedServiceAccount)
         {
-            $configurationFileArguments["GroupManagedServiceAccount"] = $this.GroupManagedServiceAccount
+            $configurationFileArguments["GroupManagedServiceAccount"] = $this.GroupManagedServiceAccount -replace '\$$', ''
         }       
         else
         {
@@ -187,7 +187,7 @@ class JeaEndpoint
                 return $false
             }
 
-            if($currentInstance.GroupManagedServiceAccount -ne $this.GroupManagedServiceAccount)
+            if($currentInstance.GroupManagedServiceAccount -ne ($this.GroupManagedServiceAccount -replace '\$$', ''))
             {
                 Write-Verbose "GroupManagedServiceAccount not equal: $($currentInstance.GroupManagedServiceAccount)"
                 return $false
@@ -290,9 +290,9 @@ class JeaEndpoint
                 $returnObject.RunAsVirtualAccountGroups = $sessionConfiguration.RunAsVirtualAccountGroups -split ';'
             }
 
-            if($sessionConfiguration.RunAsUser)
+            if($sessionConfiguration.GroupManagedServiceAccount)
             {
-                $returnObject.GroupManagedServiceAccount = $sessionConfiguration.RunAsUser
+                $returnObject.GroupManagedServiceAccount = $sessionConfiguration.GroupManagedServiceAccount
             }
 
             if($configFileArguments.TranscriptDirectory)


### PR DESCRIPTION
Hi,

This is my proposal to fix issue #28 with trailing '$' in GroupManagedServiceAccount parameter.

Something 'strange' I had to change was this part of code:
```
if($sessionConfiguration.RunAsUser)
{
    $returnObject.GroupManagedServiceAccount = $sessionConfiguration.RunAsUser
}
```

Why taking RunAsUser as value for GroupManagedServiceAccount ? Was-it a workaround for a previous WMF version not returning a correct GroupManagedServiceAccount value ?

Hope this help.
Regards

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/jea/29)
<!-- Reviewable:end -->
