### PR TITLE
Fix proposal for issue #32

### DIFF
--- a/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
+++ b/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
@@ -187,10 +187,13 @@ class JeaEndpoint
                 return $false
             }
 
-            if($currentInstance.GroupManagedServiceAccount -ne ($this.GroupManagedServiceAccount -replace '\$$', ''))
+            if($currentInstance.GroupManagedServiceAccount -or $this.GroupManagedServiceAccount)
             {
-                Write-Verbose "GroupManagedServiceAccount not equal: $($currentInstance.GroupManagedServiceAccount)"
-                return $false
+                if($currentInstance.GroupManagedServiceAccount -ne ($this.GroupManagedServiceAccount -replace '\$$', ''))
+                {
+                    Write-Verbose "GroupManagedServiceAccount not equal: $($currentInstance.GroupManagedServiceAccount)"
+                    return $false
+                }
             }
 
             if($currentInstance.TranscriptDirectory -ne $this.TranscriptDirectory)


### PR DESCRIPTION
Hi,

This is my fix proposal for issue #32.

My previous PR broke configuration without GSMA (lack of UT :-/).

We now test if GroupManagedServiceAccount is not null in expected or actual config before replacing trailing $ and check equality.

I tested (manually) with and without GMSA enabled configuration, Get, Set and Test are OK.

Regards.
Julien

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/jea/37)
<!-- Reviewable:end -->
