### PR TITLE
Fix Error and Warning Actions

### DIFF
--- a/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
+++ b/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
@@ -123,7 +123,7 @@ class JeaEndpoint
                 $breakTheGlassName = "Microsoft.PowerShell.Restricted"
                 if(-not (Get-PSSessionConfiguration -Name $breakTheGlassName -ErrorAction SilentlyContinue))
                 {
-                    Register-PSSessionConfiguration -Name $breakTheGlassName
+                    Register-PSSessionConfiguration -Name $breakTheGlassName -Force -WarningAction SilentlyContinue | Out-Null
                 }
             }
 
@@ -137,7 +137,7 @@ class JeaEndpoint
 
             ## Create the configuration file
             New-PSSessionConfigurationFile @configurationFileArguments
-            Register-PSSessionConfiguration -Name $this.EndpointName -Path $psscPath
+            Register-PSSessionConfiguration -Name $this.EndpointName -Path $psscPath -Force -WarningAction SilentlyContinue | Out-Null
 
             ## Enable PowerShell logging on the system
             $basePath = "HKLM:\Software\Policies\Microsoft\Windows\PowerShell\ScriptBlockLogging"

--- a/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
+++ b/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
@@ -132,7 +132,7 @@ class JeaEndpoint
 
             if($existingConfiguration)
             {
-                Unregister-PSSessionConfiguration -Name $this.EndpointName
+                Unregister-PSSessionConfiguration -Name $this.EndpointName -Force -WarningAction SilentlyContinue
             }
 
             ## Create the configuration file

--- a/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
+++ b/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
@@ -121,16 +121,14 @@ class JeaEndpoint
             if($this.EndpointName -eq "Microsoft.PowerShell")
             {
                 $breakTheGlassName = "Microsoft.PowerShell.Restricted"
-                if(-not (Get-PSSessionConfiguration -Name ($breakTheGlassName + "*") |
-                    Where-Object Name -eq $breakTheGlassName))
+                if(-not (Get-PSSessionConfiguration -Name $breakTheGlassName -ErrorAction SilentlyContinue))
                 {
                     Register-PSSessionConfiguration -Name $breakTheGlassName
                 }
             }
 
             ## Remove the previous one, if any.
-            $existingConfiguration = Get-PSSessionConfiguration -Name ($this.EndpointName + "*") |
-                Where-Object Name -eq $this.EndpointName
+            $existingConfiguration = Get-PSSessionConfiguration -Name $this.EndpointName -ErrorAction SilentlyContinue
 
             if($existingConfiguration)
             {
@@ -266,9 +264,7 @@ class JeaEndpoint
     [JeaEndpoint] Get()
     {
         $returnObject = New-Object JeaEndpoint
-        
-        $sessionConfiguration = Get-PSSessionConfiguration -Name ($this.EndpointName + "*") |
-            Where-Object Name -eq $this.EndpointName
+        $sessionConfiguration = Get-PSSessionConfiguration -Name $this.EndpointName -ErrorAction SilentlyContinue
 
         if((-not $sessionConfiguration) -or (-not $sessionConfiguration.ConfigFilePath))
         {


### PR DESCRIPTION
This PR makes a few subtle changes with regards to errors and warnings:

1. Use **-ErrorAction SilentlyContinue** instead of matching \* as a wildcard and piping to Where-Object when resolving a session configuration with **Get-PSSessionConfiguration**.
2. Added **-Force -WarningAction SilentlyContinue** to **Register-PSSessionConfiguration** to ignore warnings about restarting WinRM. Also discard the result by piping to **Out-Null**.
3. Added **-Force -WarningAction SilentlyContinue** to **Unregister-PSSessionConfiguration** to ignore warnings about restarting WinRM

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/jea/38)
<!-- Reviewable:end -->
