### PR TITLE
Updated ComplexObjectsEqual Method

### DIFF
--- a/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
+++ b/DSC Resource/JustEnoughAdministration/JustEnoughAdministration.psm1
@@ -494,10 +494,17 @@ class JeaEndpoint
     ## We don't need anything extensive, as we should be the only ones changing them.
     hidden [bool] ComplexObjectsEqual($object1, $object2)
     {
-        $json1 = ConvertTo-Json -InputObject $object1 -Depth 100
+        $object1ordered=[System.Collections.Specialized.OrderedDictionary]@{}
+        $object1.Keys | Sort-Object -Descending | ForEach-Object {$object1ordered.Insert(0,$_,$object1["$_"])}
+
+        $object2ordered=[System.Collections.Specialized.OrderedDictionary]@{}
+        $object2.Keys | Sort-Object -Descending | ForEach-Object {$object2ordered.Insert(0,$_,$object2["$_"])}
+
+
+        $json1 = ConvertTo-Json -InputObject $object1ordered -Depth 100
         Write-Verbose "Argument1: $json1"
 
-        $json2 = ConvertTo-Json -InputObject $object2 -Depth 100
+        $json2 = ConvertTo-Json -InputObject $object2ordered -Depth 100
         Write-Verbose "Argument2: $json2"
 
         return ($json1 -eq $json2)


### PR DESCRIPTION
Updated ComplexObjectsEqual Method.
This method compares two JSON strings that are the result of a ConvertTo-Json from two hashtables. When these hashtables have more than one key (in case you are using more than one role defition) this could fail if order is not maintained.

This example shows the objects compared when this happens. In this case the method returns a false:

[DCTEST]: [DBG]: [Process:1916]: [Runspace3]: PS C:\Windows\system32>> ConvertTo-Json ($this.ConvertStringToHashtable($currentInstance.RoleDefinitions)) -Depth 100
{
    "GOCGROUP":  {
                     "RoleCapabilities":  "JeaCompanyDC_GOC"
                 },
    "ADMDGroup":  {
                      "RoleCapabilities":  "JEA_CompanyDC_ADMD"
                  }
}

[DCTEST]: [DBG]: [Process:1916]: [Runspace3]: PS C:\Windows\system32>> ConvertTo-Json ($roleDefinitionsHash) -Depth 100
{
    "ADMDGroup":  {
                     "RoleCapabilities":  "JEA_CompanyDC_ADMD"
                  },
    "GOCGROUP":  {
                     "RoleCapabilities":  "JeaCompanyDC_GOC"
                 }
}

Converting the hashtables into [System.Collections.Specialized.OrderedDictionary] objetcs before converting them to JSON strings, solves the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/jea/57)
<!-- Reviewable:end -->
