### PR TITLE
Fix markdown link to `DSC Resource` folder by using %20 to encode the space character that caused the broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ JEA documentation has moved to MSDN -- check it out at [http://aka.ms/JEAdocs](h
 In addition to making the documentation easier to find and read, you can now [contribute to the documentation](https://github.com/PowerShell/PowerShell-Docs/blob/staging/CONTRIBUTING.md) by submitting pull requests to the *staging* branch.
 
 ## DSC Resource
-The [JEA DSC resource](./DSC Resource) can help you quickly and consistently deploy JEA endpoints across your enterprise.
+The [JEA DSC resource](./DSC%20Resource) can help you quickly and consistently deploy JEA endpoints across your enterprise.
 The *JustEnoughAdministration* DSC resource configures the PowerShell session configurations, which define the mapping of users to roles and general session security settings.
 Role capabilities belong to standard PowerShell modules, and can be deployed with the DSC [file resource](https://msdn.microsoft.com/en-us/PowerShell/DSC/fileResource).
 Check out the [Demo Config](./DSC Resource/DemoConfig.ps1) for an example of how to deploy a JEA endpoint using these DSC resources.


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/jea/63)
<!-- Reviewable:end -->
